### PR TITLE
zip files on disk instead of in memory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,8 @@
     "dotenv": "^16.0.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.7",
-    "stream": "^0.0.2"
+    "stream": "^0.0.2",
+    "yazl": "^2.5.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/frontend/src/zip-file/zip-file.controller.ts
+++ b/frontend/src/zip-file/zip-file.controller.ts
@@ -1,23 +1,35 @@
-import { Body, Controller, Post, StreamableFile } from '@nestjs/common';
-import { ZipFileService } from './zip-file.service';
+import { Body, Controller, Post, StreamableFile } from "@nestjs/common";
+import { ZipFileService } from "./zip-file.service";
 
-@Controller('zip-file')
+@Controller("zip-file")
 export class ZipFileController {
-    constructor (private readonly zipFileService: ZipFileService) {}
+  constructor(private readonly zipFileService: ZipFileService) {}
 
-    @Post('calculateVars')
-    async calculateVars(@Body() dataDto: {bottomLeftYGlobal: number, topRightYGlobal: number, bottomLeftXGlobal: number, topRightXGlobal: number}) {
-        const vars = await this.zipFileService.calculateVars(
-        dataDto.bottomLeftYGlobal, 
-        dataDto.topRightYGlobal, 
-        dataDto.bottomLeftXGlobal, 
-        dataDto.topRightXGlobal,
-        );
-        return vars; 
+  @Post("calculateVars")
+  async calculateVars(
+    @Body()
+    dataDto: {
+      bottomLeftYGlobal: number;
+      topRightYGlobal: number;
+      bottomLeftXGlobal: number;
+      topRightXGlobal: number;
     }
+  ) {
+    const vars = await this.zipFileService.calculateVars(
+      dataDto.bottomLeftYGlobal,
+      dataDto.topRightYGlobal,
+      dataDto.bottomLeftXGlobal,
+      dataDto.topRightXGlobal
+    );
+    return vars;
+  }
 
-    @Post('zip')
-    async zipFiles(@Body() dataDto: {stitchingConfig: string, urls: string[]}): Promise<StreamableFile> {
-        return new StreamableFile(await this.zipFileService.zipFiles(dataDto.stitchingConfig, dataDto.urls));
-    }
+  @Post("zip")
+  async zipFiles(
+    @Body() dataDto: { stitchingConfig: string; urls: string[] }
+  ): Promise<StreamableFile> {
+    return new StreamableFile(
+      await this.zipFileService.zipFiles2(dataDto.stitchingConfig, dataDto.urls)
+    );
+  }
 }

--- a/frontend/src/zip-file/zip-file.service.ts
+++ b/frontend/src/zip-file/zip-file.service.ts
@@ -1,47 +1,115 @@
-import { Injectable } from '@nestjs/common'
-import { HttpService } from '@nestjs/axios';
-import { lastValueFrom, map } from 'rxjs';
-import { zipFiles } from '../../util/util'
+import { Injectable } from "@nestjs/common";
+import { HttpService } from "@nestjs/axios";
+import { lastValueFrom, map } from "rxjs";
+import { zipFiles, zipFiles2 } from "../../util/util";
+const fs = require("fs");
 
 let hostname: string;
 let port: number;
 
 @Injectable()
 export class ZipFileService {
-    constructor(private httpService: HttpService) {
-        // docker hostname is the container name, use localhost for local development
-        hostname = process.env.BACKEND_URL ? process.env.BACKEND_URL : `http://localhost`;
-        // local development backend port is 3001, docker backend port is 3000
-        // port = process.env.BACKEND_URL ? 3000 : 3001;
-        port = 3000; // frontend = 8080, backend = 3000 for now
-    }
+  constructor(private httpService: HttpService) {
+    // docker hostname is the container name, use localhost for local development
+    hostname = process.env.BACKEND_URL
+      ? process.env.BACKEND_URL
+      : `http://localhost`;
+    // local development backend port is 3001, docker backend port is 3000
+    // port = process.env.BACKEND_URL ? 3000 : 3001;
+    port = 3000; // frontend = 8080, backend = 3000 for now
+  }
 
-    async calculateVars(bottomLeftYGlobal: number, topRightYGlobal: number, bottomLeftXGlobal: number, topRightXGlobal: number): Promise<any> {
-        const requestUrl = `${hostname}:${port}/data`;
-        const data = await lastValueFrom(
-        this.httpService.post(requestUrl, { bottomLeftYGlobal, topRightYGlobal, bottomLeftXGlobal, topRightXGlobal}).pipe(map((response) => response.data))
-        );
-        return data;
-    }
+  async calculateVars(
+    bottomLeftYGlobal: number,
+    topRightYGlobal: number,
+    bottomLeftXGlobal: number,
+    topRightXGlobal: number
+  ): Promise<any> {
+    const requestUrl = `${hostname}:${port}/data`;
+    const data = await lastValueFrom(
+      this.httpService
+        .post(requestUrl, {
+          bottomLeftYGlobal,
+          topRightYGlobal,
+          bottomLeftXGlobal,
+          topRightXGlobal,
+        })
+        .pipe(map((response) => response.data))
+    );
+    return data;
+  }
 
-    async zipFiles(stitchingConfig: string, urls: string[]): Promise<any> {
-        let count = 0;
-        const files = [
-        {data: Buffer.from(stitchingConfig), name: "m3d_bild.inp"}
-        ]
-        
-        for (let url of urls) {
-        count++;
-        // add the zip file
-        const data = await lastValueFrom(
-            this.httpService.get(url).pipe(map((response) => response.data))
-        );
-        console.log("Downloading file from "+url);
-        files.push({data: Buffer.from(data), name: (url.substring(url.lastIndexOf('/') + 1))})
-        if (count == urls.length) {
-            console.log("Returning zip file")
-            return await zipFiles(files);
-        }
-        }
+  /**
+   * Downloads each file into a buffer which gets passed
+   * to a util function which zips them and returns them.
+   * Done in memory, large memory size.
+   *
+   * @param stitchingConfig
+   * @param urls
+   * @returns readstream
+   */
+  async zipFiles(stitchingConfig: string, urls: string[]): Promise<any> {
+    let count = 0;
+    const files = [
+      { data: Buffer.from(stitchingConfig), name: "m3d_bild.inp" },
+    ];
+
+    for (let url of urls) {
+      count++;
+      // add the zip file
+      const data = await lastValueFrom(
+        this.httpService.get(url).pipe(map((response) => response.data))
+      );
+      console.log("Downloading file from " + url);
+      files.push({
+        data: Buffer.from(data),
+        name: url.substring(url.lastIndexOf("/") + 1),
+      });
+      if (count == urls.length) {
+        console.log("Returning zip file");
+        return await zipFiles(files);
+      }
     }
+  }
+
+  /**
+   * Saves each file to a path designated by variable filePath,
+   * A util function then zips the files on the disk
+   * The function then reads that zip file and sends it back to the front.
+   *
+   * @param stitchingConfig
+   * @param urls
+   * @returns readstream
+   */
+  async zipFiles2(stitchingConfig: string, urls: string[]): Promise<any> {
+    let count = 0;
+    const filePath = process.env.filePath;
+    let fileName = "m3d_bild.inp";
+    let files = [];
+
+    files.push(filePath + fileName);
+    await fs.writeFile(filePath + fileName, stitchingConfig, function (err) {
+      if (err) throw err;
+      console.log("Saved " + fileName);
+    });
+
+    for (let url of urls) {
+      count++;
+      const data = await lastValueFrom(
+        this.httpService.get(url).pipe(map((response) => response.data))
+      );
+      console.log("Downloading file from " + url);
+      fileName = url.split("/").pop();
+      files.push(filePath + fileName);
+      await fs.writeFile(filePath + fileName, data, function (err) {
+        if (err) throw err;
+        console.log("Saved " + fileName);
+      });
+    }
+    console.log("Zipping files.");
+    const zipFileName = await zipFiles2(files);
+    console.log("Zipping complete.");
+    const rs = fs.createReadStream(zipFileName);
+    return rs;
+  }
 }

--- a/frontend/util/util.ts
+++ b/frontend/util/util.ts
@@ -1,38 +1,59 @@
-const archiver = require('archiver');
-import { Writable } from 'stream'
+const archiver = require("archiver");
+import { Writable } from "stream";
 declare const Buffer;
+
+import { createReadStream, createWriteStream } from "fs";
+import { ZipFile } from "yazl";
 
 /**
  * @param {array<{data: Buffer, name: String}>} files
  * @returns {Promise<Buffer>}
  */
-export async function zipFiles (files) {
+export async function zipFiles(files) {
   return new Promise((resolve, reject) => {
-    const buffs = []
+    const buffs = [];
 
-    const converter = new Writable()
+    const converter = new Writable();
 
     converter._write = (chunk, encoding, cb) => {
-      buffs.push(chunk)
-      process.nextTick(cb)
-    }
+      buffs.push(chunk);
+      process.nextTick(cb);
+    };
 
-    converter.on('finish', () => {
-      resolve(Buffer.concat(buffs))
-    })
+    converter.on("finish", () => {
+      resolve(Buffer.concat(buffs));
+    });
 
-    const archive = archiver('zip')
+    const archive = archiver("zip");
 
-    archive.on('error', err => {
-      reject(err)
-    })
+    archive.on("error", (err) => {
+      reject(err);
+    });
 
-    archive.pipe(converter)
+    archive.pipe(converter);
 
     for (const file of files) {
-      archive.append(file.data, { name: file.name })
+      archive.append(file.data, { name: file.name });
     }
 
-    return archive.finalize()
-  })
+    return archive.finalize();
+  });
+}
+
+export async function zipFiles2(files: string[]): Promise<string> {
+  const zipFile = new ZipFile();
+  const zipFileName = "C:/files/zipped_files.zip";
+
+  for (const file of files) {
+    const fileName = file.substring(file.lastIndexOf("/") + 1);
+    zipFile.addReadStream(createReadStream(file), fileName);
+  }
+
+  return new Promise((resolve, reject) => {
+    zipFile.outputStream
+      .pipe(createWriteStream(zipFileName))
+      .on("finish", () => resolve(zipFileName))
+      .on("error", (error) => reject(error));
+    zipFile.end();
+  });
 }


### PR DESCRIPTION
The changes are a bit hard to see because of Prettier but the new code is in zip-file.service (function zipFiles2) and util (function zipFiles2).

Now when a user wants to download files, the files are downloaded to the path specified by the environment variable `filePath`. After all the files are downloaded, they are zipped into an archive and that archive is then streamed back to the user.