### PR TITLE
add batch file for downloading the large files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+frontend/public/js/gis/geomapping.js

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^16.18.0",
     "@types/supertest": "^2.0.11",
+    "@types/yazl": "^2.4.2",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "eslint": "^7.32.0",

--- a/frontend/public/js/gis/geomapping.js
+++ b/frontend/public/js/gis/geomapping.js
@@ -438,11 +438,11 @@ require([
 						content: "Your files are ready, click the link below to download them."
 					});
 				} else {
-					if (resJson.num <= urlsLength && (resJson.num >= prevNum || !zipping)) {
-						view.popup.content = `Downloading ${resJson.num}/${urlsLength}... please wait`;
+					if (resJson.num <= 6 && (resJson.num >= prevNum || !zipping)) {
+						view.popup.content = `Downloading ${resJson.num}/6... please wait`;
 					} else if (!zipping) {
 						zipping = true;
-						view.popup.content = `Downloading ${urlsLength}/${urlsLength}... please wait`;
+						view.popup.content = `Downloading ${urlsLength}/6... please wait`;
 					}
 					else {
 						view.popup.content = `Zipping files... please wait`;
@@ -450,7 +450,8 @@ require([
 				}
 				})
 				.catch(function(error) {
-				console.error(error);
+					console.log('interval closed error');
+					console.error(error);
 				});
 		}, 3000); // Ping the route every 3 seconds
 	  }

--- a/frontend/util/util.ts
+++ b/frontend/util/util.ts
@@ -49,11 +49,10 @@ export async function zipFiles2(
 
   console.log("Waiting 5 seconds before zipping...");
   await new Promise((resolve) => setTimeout(resolve, 5000));
-  console.log("Zipping.");
+  console.log("Zipping files.");
 
   for (const file of files) {
     const fileName = file.substring(file.lastIndexOf("/") + 1);
-    console.log(file);
     zipFile.addFile(file, fileName);
   }
 

--- a/frontend/util/util.ts
+++ b/frontend/util/util.ts
@@ -1,8 +1,8 @@
 const archiver = require("archiver");
+const https = require("https");
+const fs = require("fs");
 import { Writable } from "stream";
 declare const Buffer;
-
-import { createReadStream, createWriteStream } from "fs";
 import { ZipFile } from "yazl";
 
 /**
@@ -47,16 +47,28 @@ export async function zipFiles2(
   const zipFile = new ZipFile();
   const zipFilePath = folder + process.env.zipFileName;
 
+  console.log("Waiting 5 seconds before zipping...");
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  console.log("Zipping.");
+
   for (const file of files) {
     const fileName = file.substring(file.lastIndexOf("/") + 1);
-    zipFile.addReadStream(createReadStream(file), fileName);
+    console.log(file);
+    zipFile.addFile(file, fileName);
   }
 
   return new Promise((resolve, reject) => {
     zipFile.outputStream
-      .pipe(createWriteStream(zipFilePath))
+      .pipe(fs.createWriteStream(zipFilePath))
       .on("finish", () => resolve(zipFilePath))
       .on("error", (error) => reject(error));
     zipFile.end();
+  });
+}
+
+export async function downloadFile(url: string, dir: string): Promise<void> {
+  const file = fs.createWriteStream(dir);
+  https.get(url, function (response) {
+    response.pipe(file);
   });
 }


### PR DESCRIPTION
- Instead of downloading the files to the backend, simply add the urls to a batch file (download.bat) which gets run when the user runs start.bat.
- Fixed an issue with downloading 7z.exe and m3d_bild.exe.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-wrf-91-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-wrf-91-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-wrf/actions/workflows/merge-main.yml)